### PR TITLE
Display dependencies in build output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 #==================
 # Chrome webdriver
 #==================
-ARG CHROME_DRIVER_VERSION=2.27
 RUN CHROMEDRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` && \
     mkdir -p /opt/chromedriver-$CHROMEDRIVER_VERSION && \
     curl -sS -o /tmp/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip && \
@@ -91,3 +90,9 @@ USER jenkins
 RUN sudo chown jenkins:jenkins /app
 RUN sudo chown jenkins:jenkins /home/jenkins
 WORKDIR /app
+
+RUN echo "INSTALLED VERSIONS" \
+  && echo "  node: `node -v`" \
+  && echo "  npm: `npm -v`" \
+  && apt-cache policy google-chrome-stable | grep Installed | sed -e "s/Installed/Chrome/" \
+  && echo "  Chromedriver: `curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`"


### PR DESCRIPTION
Once this is merged I'd like to run this job(docker-xvfb), although I don't have permission to do so

Or, I can update the images manually and push them. I added the additional tag to the "legacy" images, as shown here: https://hub.docker.com/r/auth0brokkr/node-xvfb/tags/

Also - I ran this on my machine and built the node `6.9.5` image without issues.